### PR TITLE
[ESN-1439] Fix sqlfilter

### DIFF
--- a/ckanext/odata/actions.py
+++ b/ckanext/odata/actions.py
@@ -98,7 +98,7 @@ def odata(context, data_dict):
         action = t.get_action('datastore_search_sql')
 
         query = t.request.GET.get('$sqlfilter')
-        sql = "SELECT * FROM \"%s\" %s"%(resource_id,query)
+        sql = "SELECT * FROM \"%s\" %s"%(resource_id, query)
         
         data_dict = {
             'sql': sql
@@ -116,14 +116,14 @@ def odata(context, data_dict):
             'offset': offset
         }
         
-
     try:
         result = action({}, data_dict)
     except t.ObjectNotFound:
         t.abort(404, t._('DataStore resource not found'))
     except t.NotAuthorized:
         t.abort(401, t._('DataStore resource not authourized'))
-    
+    except t.ValidationError as e:
+        return json.dumps(e.error_dict)
     
     if not t.request.GET.get('$sqlfilter'):
         num_results = result['total']

--- a/ckanext/odata/actions.py
+++ b/ckanext/odata/actions.py
@@ -96,10 +96,8 @@ def odata(context, data_dict):
     # as they should be specified by the sql query
     if t.request.GET.get('$sqlfilter'):
         action = t.get_action('datastore_search_sql')
-        
-        # Replace double quotes with single quotes to avoid syntax errors.
-        # Not sure if this will cause us any trouble later.
-        query = t.request.GET.get('$sqlfilter').replace('"','\'')
+
+        query = t.request.GET.get('$sqlfilter')
         sql = "SELECT * FROM \"%s\" %s"%(resource_id,query)
         
         data_dict = {


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/ESN-1439)

## Description
<!--- Describe these changes in detail --->
This PR adds the following:
- Updates the handling of the `$sqlfilter` query option to keep double quotes
- Catches ValidationError when calling the datastore API

**Updates the handling of the `$sqlfilter` query option to keep double quotes**
Previously double quote characters were replace with single quote characters. Double quotes should be left as is since they are used for DB identifiers like column names. There should be no impact to security since the query to sent to the datastore_search_sql API call, which is limited to read operations on the datastore.

This fix would allow the following odata query to work
```
https://data.cnra.ca.gov/datastore/odata3.0/af157380-fb42-4abf-b72a-6f9f98868077?$sqlfilter=WHERE "SITE_CODE"='341081N1188965W001'
```

**Catches ValidationError when calling the datastore API**
Previously syntax errors with the odata endpoint would result in a server error. To fix this we catch errors of type `ValidationError` and return the error message from the datastore API.

## Testing
- Install the odata extension and checkout this PR
- Go to a resource with data in the datastore
- Query the odata endpoint with a `$sqlfilter` query option containing a where clause. Replace `{resource_id}`, `{column_name}`, and `{value}` with appropriate values. In case of a syntax error in the where clause, a human readable error message should be returned instead of server error.
```
http://127.0.0.1:5000/datastore/odata3.0/{resource_id}?$sqlfilter=where "{column_name}"='{value}'
```