### PR TITLE
[ESN-2880] Update Python API example to python3

### DIFF
--- a/ckanext/odata/templates/ajax_snippets/api_info.html
+++ b/ckanext/odata/templates/ajax_snippets/api_info.html
@@ -138,10 +138,10 @@ Example
       <div id="collapse-python" class="accordion-body collapse">
         <div class="accordion-inner">
           <pre>
-import urllib
+from urllib import request
 url = '{{ h.url_for(qualified=True, controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5) + '&q=title:jones' }}'  {# not urlencoding the ":" because its clearer #}
-fileobj = urllib.urlopen(url)
-print fileobj.read()
+fileobj = request.urlopen(url)
+print(fileobj.read())
 </pre>
         </div>
       </div>

--- a/ckanext/odata/templates/ajax_snippets/api_info.html
+++ b/ckanext/odata/templates/ajax_snippets/api_info.html
@@ -138,10 +138,12 @@ Example
       <div id="collapse-python" class="accordion-body collapse">
         <div class="accordion-inner">
           <pre>
-from urllib import request
+import json
+import urllib.request
 url = '{{ h.url_for(qualified=True, controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5) + '&q=title:jones' }}'  {# not urlencoding the ":" because its clearer #}
-fileobj = request.urlopen(url)
-print(fileobj.read())
+fileobj = urllib.request.urlopen(url)
+fileobj_json = json.loads(fileobj.read())
+print(fileobj_json)
 </pre>
         </div>
       </div>

--- a/ckanext/odata/templates/ajax_snippets/api_info.html
+++ b/ckanext/odata/templates/ajax_snippets/api_info.html
@@ -142,9 +142,9 @@ import json
 import urllib.request
 url = '{{ h.url_for(qualified=True, controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5) + '&q=title:jones' }}'  {# not urlencoding the ":" because its clearer #}
 fileobj = urllib.request.urlopen(url)
-fileobj_json = json.loads(fileobj.read())
-print(fileobj_json)
-</pre>
+response_dict = json.loads(fileobj.read())
+print(response_dict)
+          </pre>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [ESN-2880](https://opengovinc.atlassian.net/browse/ESN-2880)

## Description
<!--- Describe these changes in detail --->
This PR updates the python example under the "Data API" button to python3 from python2.

## Test Procedure
<!--- List the steps involved to test the changes --->
1. Checkout the branch for this PR and run `python setup.py develop`
2. In your ini enable the `oodata` plugin.
3. Start CKAN, navigate to an existing resource or create a dataset with one one.
4. Click the "Dataset API" button when viewing the resource.
5. Scroll down to bottom and try to use the Python example in python3/


## Approval Criteria 
<!--- Describe the expected results of testing --->
- Code in example is correct and works

## Submitter Checklist
- [ ] The code looks good to me (LGTM)
- [ ] I have tested the changes locally
- [ ] The new changes does not affect web accessibility
