### PR TITLE
Update identifiers

### DIFF
--- a/ckanext/odata/actions.py
+++ b/ckanext/odata/actions.py
@@ -51,6 +51,9 @@ def name_2_xml_tag(name):
         [#x203F-#x2040]
     '''
 
+    # replace '%' with 'Percent' to avoid duplicate identifier with different data types
+    name = name.replace('%', 'Percent')
+
     # leave well-formed XML element characters only
     name = re.sub(name_pattern, '', name)
 


### PR DESCRIPTION
# Description
Odata identifiers are alphanumeric with underscore characters only. Special characters are replaced with an empty string. This causes an issue when 2 identifiers are the same except one has a special character (i.e. `Clients Served` vs `Clients Served %`). When the Odata $metadata document loads there'll be 2 identifiers that are the same, but potentially with different data types (double vs string).

The specific error is `Some type has conflicting definitions for the property {identifier}`.

# Fixes
This PR fixes an edge case by replacing '%' characters with 'Percent' to avoid duplicate identifiers.
The max character limit for field names is 128 in Odata, but the max limit is 64 in CKAN so we should be fine.

https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_SimpleIdentifier